### PR TITLE
Update rest-client to 1.7.3

### DIFF
--- a/apple_vpp.gemspec
+++ b/apple_vpp.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rest-client', '~> 1.6.7'
+  spec.add_dependency 'rest-client', '~> 1.7.3'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/apple_vpp.gemspec
+++ b/apple_vpp.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rest-client', '~> 1.7.3'
+  spec.add_dependency 'rest-client', '~> 1.8.0'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/apple_vpp/version.rb
+++ b/lib/apple_vpp/version.rb
@@ -1,3 +1,3 @@
 module AppleVPP
-  VERSION = "3.0.2"
+  VERSION = "3.0.3"
 end

--- a/spec/apple_vpp/api_spec.rb
+++ b/spec/apple_vpp/api_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe AppleVPP::API do
+describe AppleVPP::Client do
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ require 'apple_vpp'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
rest-client v1.7.3 is a security release that redacts passwords from logs - https://github.com/rest-client/rest-client/blob/master/history.md#173